### PR TITLE
Update to use relp plugin 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To use the plugin just add tou your fluent.conf file:
   port XXXX
   #optionally, specify a tag with which to mark messages received over this connection
   tag your_tag_for_relp
+  #optionally, specify a field name to record relp peer information
+  peer_field your_field_for_relp_peer_infomation
   #optionally, determine remote IP to bind to, by default binds to all incoming connections
   bind XX.XX.XX.XX
   #if you want to use TLS encryption specify this

--- a/fluent-plugin-relp.gemspec
+++ b/fluent-plugin-relp.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'simplecov', '~> 0'
   gem.add_development_dependency 'test-unit', '~> 3.1'
   gem.add_runtime_dependency 'fluentd', '~> 1'
-  gem.add_runtime_dependency 'relp', '~> 0.2'
+  gem.add_runtime_dependency 'relp', '~> 1.0'
 end

--- a/lib/fluent/plugin/in_relp.rb
+++ b/lib/fluent/plugin/in_relp.rb
@@ -76,12 +76,11 @@ module Fluent
     rescue StandardError => e
       log.error 'unexpected error', error: e, error_class: e.class
       log.error_backtrace
-      retry
     end
 
-    def on_message(msg)
+    def on_message(msg, peer)
       time = Engine.now
-      record = { 'message' => msg }
+      record = { 'message' => msg.chomp, 'peer' => peer }
       router.emit(@tag, time, record)
     rescue StandardError => e
       log.error msg.dump, error: e, error_class: e.class

--- a/lib/fluent/plugin/relp/version.rb
+++ b/lib/fluent/plugin/relp/version.rb
@@ -1,5 +1,5 @@
 module Fluent
   module RelpPlugin
-    VERSION = '0.3.0'.freeze
+    VERSION = '1.0.0'.freeze
   end
 end


### PR DESCRIPTION
Matches https://github.com/ViaQ/Relp/pull/19.

* Update to use the new version of relp library.
* Drop the old ssl_config option.
* Add peer_field config.

Note the msg.chomp before before passing the message to fluentd. This is done as a work around for fluentd core parse_syslog not being able to handle `\n` at the end of a syslog message. See https://github.com/fluent/fluentd/pull/2767 for more information.